### PR TITLE
Check for dist and for actual index.html availability before starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ You also have to provide the port at which this server will be listening
 export UI_PORT=9001
 ```
 
-Finally, inside the directory where your /dist folder lives, run the following:
+Finally, inside the directory where your /dist folder lives
+(which HAS to include an index.html file), run the following:
 
 ```bash
 static-frontend-server -c your-config-file.json
@@ -79,14 +80,3 @@ This tool will read the above configuration file,
 evaluate the environment variables that you reference,
 create the two proxy definitions
 and finally will serve your built Vue files at the defined UI_PORT
-
-## TODOs
-
-- Handle http vs https
-- add tests
-- add proper output for the different errors
-- add ability to read the serving port from command line and override the env variable UI_PORT
-- add CI and packaging ability for standalone binary
-- check presence of dist folder and its contents
-- add ability to not use a config file if no proxies are needed
-- add ability to select location of /dist folder

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "static-frontend-server",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "An express server to serve built apps, supporting configurable proxies",
   "author": "Ioannis Gkikas",
   "license": "MIT",
@@ -18,7 +18,7 @@
   ],
   "private": false,
   "scripts": {
-    "start": "node index.js",
+    "start": "node cli.js",
     "lint": "./node_modules/.bin/eslint *.js",
     "test:unit": "jest"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 "use-strict"
 
+const fs = require("fs")
+const path = require("path")
+
 const express = require("express")
 const serveStatic = require("serve-static")
 const history = require("connect-history-api-fallback")
@@ -10,13 +13,23 @@ const { generateProxies } = require("./proxyGenerator.js")
 
 const UI_PORT = process.env.UI_PORT
 
+const checkContentsToServe = pathToStaticContent => {
+  if (!fs.existsSync(pathToStaticContent + path.sep + "index.html")) {
+    throw new Error(`There is no index.html to serve under ${pathToStaticContent}`)
+  }
+}
+
 const startStaticServer = (setupProxyTable, configurationFilePath) => {
+  const pathToStaticContent = process.cwd() + path.sep + "dist"
+  checkContentsToServe(pathToStaticContent)
+
   const app = express()
 
   const middleware = history({
     verbose: true
   })
-  app.use(serveStatic(process.cwd() + "/dist"))
+
+  app.use(serveStatic(pathToStaticContent))
   app.use(middleware)
 
   if (setupProxyTable) {


### PR DESCRIPTION
  - fail the invocation if there is no actual index.html to serve

  - fix npm run start script to run cli.js instead